### PR TITLE
Add time-based coloring and stackcollapse-time script

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -823,7 +823,7 @@ foreach (@SortedData) {
 
   	# there may be an extra samples column for differentials / cpu time:
 	
-  	$	delta = undef;
+  	$delta = undef;
 	if (defined $samples2) {
 	    if ($colors =~ /^timep/) {
 	            # we are hijacking the "delta" and "maxdelta" variables. 

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -508,7 +508,7 @@ sub color {
 		$v3 = random_namehash($name);
 	}
 
-        if ($colortime && defined $ind && $ind >= 0 && $n_samples >= 0) {
+        if ($colortime && defined $ind && $ind >= 0 && $n_samples > 0) {
 	    $v1 = 2 * $ind / $n_samples;
         } 
 

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -121,7 +121,7 @@ my $stackreverse = 0;           # reverse stack order, switching merge end
 my $inverted = 0;               # icicle graph
 my $flamechart = 0;             # produce a flame chart (sort by time, do not merge stacks)
 my $negate = 0;                 # switch differential hues
-my $colortime;			# maps primary (v1) color channel to index defined in the stack traces
+my $colortime;					# maps primary (v1) color channel to index defined in the stack traces
 my $titletext = "";             # centered heading
 my $titledefault = "Flame Graph";	# overwritten by --title
 my $titleinverted = "Icicle Graph";	#   "    "
@@ -199,7 +199,7 @@ my $ypad1 = $fontsize * 3;      # pad top, include title
 my $ypad2 = $fontsize * 2 + 10; # pad bottom, include labels
 my $ypad3 = $fontsize * 2;      # pad top, include subtitle (optional)
 my $xpad = 10;                  # pad lefm and right
-my $framepad = 1;		# vertical padding for frames
+my $framepad = 1;				# vertical padding for frames
 my $depthmax = 0;
 my %Events;
 my %nameattr;
@@ -732,10 +732,11 @@ sub flow {
 
       if (defined $d) {
         if ($colors =~ /^timep/) {
+			# --color=timep[r] will hijack delta and use it as a 2nd independent time / sample count
           $Tmp{$k}->{delta} = $d;
-	} else {
+		} else {
            $Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
-	}
+		}
       }
       if (defined $iw) {
         $Tmp{$k}->{indwall} = $iw;
@@ -808,29 +809,29 @@ foreach (@SortedData) {
 	  unless (defined $samples and defined $stack) {
 		  ++$ignored;
 		  next;
-	  }
+	}
 	if ($stack =~ /^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/) {
-		  $samples2 = $samples;
-		  ($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
-      if ($samples2 =~ /^(.*):(.*)$/) {
-        ($samples2, $inddelta) = $samples2 =~ (/^(\d+):(\d+)$/); 
-      }
- 	  }
-      if ($samples =~ /^(.*):(.*)$/) {
-        ($samples, $indwall) = $samples =~ (/^(\d+):(\d+)$/); 
-      }          
+		$samples2 = $samples;
+		($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
+  	  	if ($samples2 =~ /^(.*):(.*)$/) {
+   	  		($samples2, $inddelta) = $samples2 =~ (/^(\d+):(\d+)$/); 
+		}
+  	}
+   	if ($samples =~ /^(.*):(.*)$/) {
+       	($samples, $indwall) = $samples =~ (/^(\d+):(\d+)$/); 
+  	}          
 
-  # there may be an extra samples column for differentials / cpu time:
+  	# there may be an extra samples column for differentials / cpu time:
 	
-  $delta = undef;
+  	$	delta = undef;
 	if (defined $samples2) {
-	        if ($colors =~ /^timep/) {
+	    if ($colors =~ /^timep/) {
 	            # we are hijacking the "delta" and "maxdelta" variables. 
 	            # samples is really "wall-clock time". samples2 is really "cpu time".
               $delta = $samples2;
 		} else {
 		    $delta = $samples2 - $samples;
-    }
+    	}
 		$maxdelta = abs($delta) if abs($delta) > $maxdelta;
 	}
    

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -84,8 +84,9 @@
 #
 # CDDL HEADER END
 #
+# ??-Jul-2025   Anthony Barone  Added support for time-based coloring.
 # 11-Oct-2014	Adrien Mahieux	Added zoom.
-# 21-Nov-2013   Shawn Sterling  Added consistent palette file option
+# 21-Nov-2013   Shawn Sterling  Added consistent palette file option.
 # 17-Mar-2013   Tim Bunce       Added options and more tunables.
 # 15-Dec-2011	Dave Pacheco	Support for frames with whitespace.
 # 10-Sep-2011	Brendan Gregg	Created this.
@@ -120,6 +121,7 @@ my $stackreverse = 0;           # reverse stack order, switching merge end
 my $inverted = 0;               # icicle graph
 my $flamechart = 0;             # produce a flame chart (sort by time, do not merge stacks)
 my $negate = 0;                 # switch differential hues
+my $colortime;			# maps primary (v1) color channel to index defined in the stack traces
 my $titletext = "";             # centered heading
 my $titledefault = "Flame Graph";	# overwritten by --title
 my $titleinverted = "Icicle Graph";	#   "    "
@@ -143,11 +145,12 @@ USAGE: $0 [options] infile > outfile.svg\n
 	--nametype TEXT  # name type label (default "Function:")
 	--colors PALETTE # set color palette. choices are: hot (default), mem,
 	                 # io, wakeup, chain, java, js, perl, red, green, blue,
-	                 # aqua, yellow, purple, orange
+	                 # aqua, yellow, purple, orange, time, timep, timepr
 	--bgcolors COLOR # set background colors. gradient choices are yellow
 	                 # (default), blue, green, grey; flat colors use "#rrggbb"
 	--hash           # colors are keyed by function name hash
 	--random         # colors are randomly generated
+	--time           # colors are determined from sample counts (time spent per-function)
 	--cp             # use consistent palette (palette.map)
 	--reverse        # generate stack-reversed flame graph
 	--inverted       # icicle graph
@@ -185,6 +188,7 @@ GetOptions(
 	'inverted'    => \$inverted,
 	'flamechart'  => \$flamechart,
 	'negate'      => \$negate,
+	'time'	      => \$colortime,
 	'notes=s'     => \$notestext,
 	'help'        => \$help,
 ) or usage();
@@ -395,8 +399,100 @@ sub random_namehash {
 	return rand(1)
 }
 
+my $max_wall;
+my $max_cpu;
+my $n_samples;
+
+sub color_timep {
+  my ($type, $name, $count_wall, $ind_wall, $count_cpu, $ind_cpu) = @_;
+  my ($saturation, $intensity, $i2, $s, $type0);
+  my ($r, $g, $b);
+
+    if ($type eq "timep") {
+      	    if (defined $ind_wall && $ind_wall >= 0 && defined $n_samples && $n_samples > 0 ) {
+	    	    $intensity = $ind_wall / (2 * $n_samples);       
+      	    } else {
+	    	    $intensity  = (4 / 3) * (1 - (1 / (1 + ($count_wall / $max_wall) ** 2) ** 2));
+      	    }
+      	    if (defined $count_cpu && $count_cpu > 0) {
+      		    if (defined $ind_cpu && $ind_cpu >= 0 && defined $n_samples && $n_samples > 0 ) {
+      			    $saturation = $ind_cpu / (2 * $n_samples);       
+      		    } else {
+      			    $saturation  = 1 - (1 / (1 + ($count_cpu / $count_wall) ** 2) ** 2);      		    }
+      	    } else {
+      		    $saturation = 1
+      	    }
+      	    $type0 = "time";
+    } elsif (defined $count_cpu && $count_cpu > 0 && $type eq "timepr") {
+     	   if (defined $ind_cpu && $ind_cpu >= 0 && defined $n_samples && $n_samples > 0 ) {
+	   	   $intensity = $ind_cpu / (2 * $n_samples);       
+     	   } else {
+	   	   $intensity  = (4 / 3) * (1 - (1 / (1 + ($count_cpu / $max_cpu) ** 2) ** 2));
+     	   }
+     	   if (defined $count_wall && $count_wall > 0) {
+     		   if (defined $ind_wall && $ind_wall >= 0 && defined $n_samples && $n_samples > 0 ) {
+     			   $saturation = $ind_wall / (2 * $n_samples);       
+     		   } else {
+			   $saturation = 1 - (1 / (1 + $count_wall / $count_cpu) ** 2);
+     		   }
+     	   } else {
+     		   $saturation = 1
+     	   }
+     	   $type0 = "time";
+   } else {
+     	   if (defined $ind_wall && $ind_wall >= 0 && defined $n_samples && $n_samples > 0 ) {
+	   	   $intensity = $ind_wall / (2 * $n_samples);       
+     	   } else {
+	   	   $intensity  = (4 / 3) * (1 - (1 / (1 + ($count_wall / $max_wall) ** 2) ** 2));
+     	   }
+     	   $saturation = 1;  
+     	   $type0 = "time";
+   }
+  
+  $intensity  = 1 if $intensity > 1;
+  $intensity  = 0 if $intensity < 0;
+  $saturation = 1 if $saturation > 1;
+  $saturation = 0 if $saturation < 0;
+
+  $saturation  = (4 / 3) * (1 - (1 / (1 + ($saturation) ** 2) ** 2));
+
+  if ($colors =~ /^timep/) {
+    if ($name =~ m:_\[f\]$:) { 
+      $type0 = "function";
+    } elsif ($name =~ m:_\[s\]$:) {
+      $type0 = "subshell";
+    } else {			
+      $type0 = "time";
+    }
+  }
+
+  if ($type0 eq "time") {
+    $i2 = $intensity ** 2;
+    $r = ((255 * ($intensity + sqrt($intensity)) / 2) * $saturation + 255 * (1 - $saturation));
+    $g = ((255 * (1 - ((1 - 2 * $intensity) ** 2)) * (1 - $i2)) * $saturation + 255 * (1 - $saturation));
+    $b = ((255 * (1 - $intensity) * (1 - $i2) * (1 - ($intensity * $i2))) * $saturation + 255 * (1 - $saturation));
+    $s = $saturation * (1 + 255 / ($r + $g + $b)) / 2;
+    $r = int($r);
+    $g = int($g * $s + 255 * (1 - $s));
+    $b = int($b);
+  } else {
+        $saturation = (1 / 4) + ($saturation / 2);
+  	if ($type0 eq "function") {
+		  $r = ((185 + int(55 * $intensity)) * $saturation + 255 * (1 - $saturation));
+		  $g = ((95 + int(55 * $intensity)) * $saturation + 255 * (1 - $saturation));
+      $b = ((205 + int(50 * $intensity)) * $saturation + 255 * (1 - $saturation));
+  	} elsif ($type0 eq "subshell") {
+		  $r = ((155 + int(55 * $intensity)) * $saturation + 255 * (1 - $saturation));
+		  $g = ((55 + int(55 * $intensity)) * $saturation + 255 * (1 - $saturation));
+		  $b = ((175 + int(55 * $intensity)) * $saturation + 255 * (1 - $saturation));
+  	}
+  }
+
+  return "rgb($r,$g,$b)";
+}
+
 sub color {
-	my ($type, $hash, $name) = @_;
+	my ($type, $hash, $name, $ind) = @_;
 	my ($v1, $v2, $v3);
 
 	if ($hash) {
@@ -411,6 +507,10 @@ sub color {
 		$v2 = random_namehash($name);
 		$v3 = random_namehash($name);
 	}
+
+        if ($colortime && defined $ind && $ind >= 0 && $n_samples >= 0) {
+	    $v1 = 2 * $ind / $n_samples;
+        } 
 
 	# theme palettes
 	if (defined $type and $type eq "hot") {
@@ -596,7 +696,7 @@ my %Tmp;
 
 # flow() merges two stacks, storing the merged frames and value data in %Node.
 sub flow {
-	my ($last, $this, $v, $d) = @_;
+	my ($last, $this, $v, $d, $iw, $id) = @_;
 
 	my $len_a = @$last - 1;
 	my $len_b = @$this - 1;
@@ -617,18 +717,35 @@ sub flow {
 		if (defined $Tmp{$k}->{delta}) {
 			$Node{"$k;$v"}->{delta} = delete $Tmp{$k}->{delta};
 		}
+		if (defined $Tmp{$k}->{indwall}) {
+			$Node{"$k;$v"}->{indwall} = delete $Tmp{$k}->{indwall};
+		}
+		if (defined $Tmp{$k}->{inddelta}) {
+			$Node{"$k;$v"}->{inddelta} = delete $Tmp{$k}->{inddelta};
+		}
 		delete $Tmp{$k};
 	}
 
 	for ($i = $len_same; $i <= $len_b; $i++) {
 		my $k = "$this->[$i];$i";
 		$Tmp{$k}->{stime} = $v;
-		if (defined $d) {
-			$Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
-		}
-	}
 
-        return $this;
+      if (defined $d) {
+        if ($colors =~ /^timep/) {
+          $Tmp{$k}->{delta} = $d;
+	} else {
+           $Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
+	}
+      }
+      if (defined $iw) {
+        $Tmp{$k}->{indwall} = $iw;
+      }
+      if (defined $id) {
+        $Tmp{$k}->{inddelta} = $id;
+      }
+  
+  }
+  return $this;
 }
 
 # parse input
@@ -637,29 +754,39 @@ my @SortedData;
 my $last = [];
 my $time = 0;
 my $delta = undef;
+my $indwall = undef;
+my $inddelta = undef;
 my $ignored = 0;
 my $line;
+my $maxwall = 0;
+my $sumwall = 0;
 my $maxdelta = 1;
+my $sumdelta = 0;
+my $nsamples = 0;
+
+if ($colors =~ /^timep/) {
+    $maxdelta = 0;
+}
 
 # reverse if needed
 foreach (<>) {
 	chomp;
 	$line = $_;
-	if ($stackreverse) {
+    if ($stackreverse) {
 		# there may be an extra samples column for differentials
 		# XXX todo: redo these REs as one. It's repeated below.
-		my($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+		my($stack, $samples) = (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
 		my $samples2 = undef;
-		if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
+		if ($stack =~ /^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d+)?)?)$/) {
 			$samples2 = $samples;
-			($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
+			($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
 			unshift @Data, join(";", reverse split(";", $stack)) . " $samples $samples2";
 		} else {
 			unshift @Data, join(";", reverse split(";", $stack)) . " $samples";
 		}
 	} else {
 		unshift @Data, $line;
-	}
+	}       
 }
 
 if ($flamechart) {
@@ -674,23 +801,41 @@ foreach (@SortedData) {
 	chomp;
 	# process: folded_stack count
 	# eg: func_a;func_b;func_c 31
-	my ($stack, $samples) = (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
-	unless (defined $samples and defined $stack) {
-		++$ignored;
-		next;
-	}
+	my ($stack, $samples);
+  my $samples2 = undef;
 
-	# there may be an extra samples column for differentials:
-	my $samples2 = undef;
-	if ($stack =~ /^(.*)\s+?(\d+(?:\.\d*)?)$/) {
-		$samples2 = $samples;
-		($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?:\.\d*)?)$/);
-	}
-	$delta = undef;
+  ($stack, $samples) = (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
+	  unless (defined $samples and defined $stack) {
+		  ++$ignored;
+		  next;
+	  }
+	if ($stack =~ /^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/) {
+		  $samples2 = $samples;
+		  ($stack, $samples) = $stack =~ (/^(.*)\s+?(\d+(?::?\d+)?(?:\.\d*(?::?\d*)?)?)$/);
+      if ($samples2 =~ /^(.*):(.*)$/) {
+        ($samples2, $inddelta) = $samples2 =~ (/^(\d+):(\d+)$/); 
+      }
+ 	  }
+      if ($samples =~ /^(.*):(.*)$/) {
+        ($samples, $indwall) = $samples =~ (/^(\d+):(\d+)$/); 
+      }          
+
+  # there may be an extra samples column for differentials / cpu time:
+	
+  $delta = undef;
 	if (defined $samples2) {
-		$delta = $samples2 - $samples;
+	        if ($colors =~ /^timep/) {
+	            # we are hijacking the "delta" and "maxdelta" variables. 
+	            # samples is really "wall-clock time". samples2 is really "cpu time".
+              $delta = $samples2;
+		} else {
+		    $delta = $samples2 - $samples;
+    }
 		$maxdelta = abs($delta) if abs($delta) > $maxdelta;
 	}
+   
+	$maxwall = $samples if $samples > $maxwall;
+	$nsamples += 1;
 
 	# for chain graphs, annotate waker frames with "_[w]", for later
 	# coloring. This is a hack, but has a precedent ("_[k]" from perf).
@@ -708,15 +853,22 @@ foreach (@SortedData) {
 	}
 
 	# merge frames and populate %Node:
-	$last = flow($last, [ '', split ";", $stack ], $time, $delta);
+	$last = flow($last, [ '', split ";", $stack ], $time, $delta, $indwall, $inddelta);
 
-	if (defined $samples2) {
+	if ($colors eq "timep") {
+ 		$time += $samples;
+ 	} elsif (defined $samples2) {
 		$time += $samples2;
 	} else {
 		$time += $samples;
 	}
 }
-flow($last, [], $time, $delta);
+flow($last, [], $time, $delta, $indwall, $inddelta);
+
+if ($colortime) {
+    (defined $indwall) or warn "Coloring by sample count / time requires running the input stack traces through 'stackcollapse-time.bash'. Standard function-name-based coloring ill be used.\n";
+    ($colors !~ /^time/) and (defined $indwall and defined $delta) and warn "Coloring by sample count / time is not supported when using the delta between two input sample counts / times.\nIf the 2nd input is an intependent sample count / time measurement, use '--color=timep' instead.\n"
+}
 
 if ($countname eq "samples") {
 	# If $countname is used, it's likely that we're not measuring in stack samples
@@ -742,6 +894,9 @@ if ($timemax and $timemax < $time) {
 	undef $timemax;
 }
 $timemax ||= $time;
+$max_wall ||= $maxwall;
+$max_cpu ||= $maxdelta;
+$n_samples ||= $nsamples;
 
 my $widthpertime = ($imagewidth - 2 * $xpad) / $timemax;
 
@@ -1218,6 +1373,8 @@ while (my ($id, $node) = each %Node) {
 	my ($func, $depth, $etime) = split ";", $id;
 	my $stime = $node->{stime};
 	my $delta = $node->{delta};
+        my $indwall = $node->{indwall};
+        my $inddelta = $node->{inddelta};
 
 	$etime = $timemax if $func eq "" and $depth == 0;
 
@@ -1239,6 +1396,10 @@ while (my ($id, $node) = each %Node) {
 		=~ s/(^[-+]?\d+?(?=(?>(?:\d{3})+)(?!\d))|\G\d{3}(?=\d))/$1,/g;
 
 	my $info;
+	my $samples2 = undef;
+	my $iwall = undef;
+	my $icpu = undef;
+
 	if ($func eq "" and $depth == 0) {
 		$info = "all ($samples_txt $countname, 100%)";
 	} else {
@@ -1250,7 +1411,17 @@ while (my ($id, $node) = each %Node) {
 		$escaped_func =~ s/>/&gt;/g;
 		$escaped_func =~ s/"/&quot;/g;
 		$escaped_func =~ s/_\[[kwij]\]$//;	# strip any annotation
+
+		if (defined $indwall) {
+			$iwall = sprintf "%.0f", $indwall;
+		}
+		if (defined $inddelta) {
+			$icpu = sprintf "%.0f", $inddelta;
+		}		
 		unless (defined $delta) {
+			$info = "$escaped_func ($samples_txt $countname, $pct%)";
+		} elsif ($colors =~ /^timepr?/) {
+			$samples2 = sprintf "%.0f", ($etime - $delta) * $factor;
 			$info = "$escaped_func ($samples_txt $countname, $pct%)";
 		} else {
 			my $d = $negate ? -$delta : $delta;
@@ -1265,7 +1436,9 @@ while (my ($id, $node) = each %Node) {
 	$im->group_start($nameattr);
 
 	my $color;
-	if ($func eq "--") {
+	if ($colors =~ /^time/) {
+		$color = color_timep($colors, $func, $samples, $iwall, $samples2, $icpu);
+	} elsif ($func eq "--") {
 		$color = $vdgrey;
 	} elsif ($func eq "-") {
 		$color = $dgrey;
@@ -1274,7 +1447,7 @@ while (my ($id, $node) = each %Node) {
 	} elsif ($palette) {
 		$color = color_map($colors, $func);
 	} else {
-		$color = color($colors, $hash, $func);
+		$color = color($colors, $hash, $func, $iwall);
 	}
 	$im->filledRectangle($x1, $y1, $x2, $y2, $color, 'rx="2" ry="2"');
 

--- a/stackcollapse-time.bash
+++ b/stackcollapse-time.bash
@@ -107,9 +107,11 @@ stackcollapse-time() {
     fi
 }
 
-if (( $! == 0 )) && ! [[ -t 0 ]]; then
+if (( $# == 0 )) && ! [[ -t 0 ]]; then
+    # stack traces were passed on stdin
     stackcollapse-time <(cat <&0)
 else
+    # we were passed file(s) with the stack traces
     until (( $# == 0 )); do
         stackcollapse-time "${1}"
         shift 1

--- a/stackcollapse-time.bash
+++ b/stackcollapse-time.bash
@@ -17,18 +17,22 @@ stackcollapse-time() {
 
     shopt -s extglob
 
-    [[ -f "$1" ]] || {
+    [[ -e "$1" ]] || {
         printf '\nERROR: no file found at "%s"...ABORTING\n\n' "${1}"
         return 1
     }
 
-    local wallTimeN cpuTimeN wallTimeCDF_csum cpuTimeCDF_csum kk kk0 a b c n cpuTimeFlag
+    local wallTimeN cpuTimeN wallTimeCDF_csum cpuTimeCDF_csum kk kk0 a b c n cpuTimeFlag stackOrig
     local -a stackA wallTimeA cpuTimeA wallTimeSortA cpuTimeSortA wallTimeCDF_map0 cpuTimeCDF_map0 wallTimeCDF_map cpuTimeCDF_map
 
+    stackOrig="$(cat "${1}")"
+
      # seperate logs into stack / wall time / cpu time
-    mapfile -t stackA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\1/' <"${1}") 
-    mapfile -t wallTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\1/' <"${1}") 
-    mapfile -t cpuTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\2/' <"${1}" | grep -E '.+') 
+    mapfile -t stackA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\1/' <<<"${stackOrig}") 
+    mapfile -t wallTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\1/' <<<"${stackOrig}") 
+    mapfile -t cpuTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\2/' <<<"${stackOrig}" | grep -E '.+') 
+
+    unset "stackOrig"
 
     if (( ${#cpuTimeA[@]} == 0 )); then
         cpuTimeFlag=false

--- a/stackcollapse-time.bash
+++ b/stackcollapse-time.bash
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash -O extglob
+
+stackcollapse-time() {
+## Emperically creates a non-linear colorspace mapping (using a screen-space-weighted  CDF) that 
+#      ensure that the colorspace is perceptually uniform and has equal spatial distribution.
+#
+# USAGE:   _timep_PROCESS_FLAMEGRAPH out.folded >out.folded.mod
+#
+# OUTPUT:  for each line in out.folded:
+#    a;b;c;d; time [time2] --> a;b;c;d; time:ind [time2:ind2]
+#  
+#    both "ind" and (if time2 is present) "ind2" are linear maps to the colorspce
+#    that range between 0 and 2 * N (N = total number of samples / lines in out.folded)
+#
+#    this output style is designed to work with `flamegraph.pl --color=time[p[r]]`
+
+    shopt -s extglob
+
+    [[ -f "$1" ]] || {
+        printf '\nERROR: no file found at "%s"...ABORTING\n\n' "${1}"
+        return 1
+    }
+
+    local wallTimeN cpuTimeN wallTimeCDF_csum cpuTimeCDF_csum kk kk0 a b c n cpuTimeFlag
+    local -a stackA wallTimeA cpuTimeA wallTimeSortA cpuTimeSortA wallTimeCDF_map0 cpuTimeCDF_map0 wallTimeCDF_map cpuTimeCDF_map
+
+     # seperate logs into stack / wall time / cpu time
+    mapfile -t stackA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\1/' <"${1}") 
+    mapfile -t wallTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\1/' <"${1}") 
+    mapfile -t cpuTimeA < <(sed -E 's/^(.*)(([[:space:]]+[0-9]+)+)$/\2 /; s/^[[:space:]]+([0-9]+)[[:space:]]+([0-9]*)[[:space:]]*$/\2/' <"${1}" | grep -E '.+') 
+
+    if (( ${#cpuTimeA[@]} == 0 )); then
+        cpuTimeFlag=false
+    else
+        cpuTimeFlag=true
+    fi
+
+    # sort times then prepend line numbers to start
+    mapfile -t wallTimeSortA < <( printf '%s\n' "${wallTimeA[@]}" | sort -n | grep -nE '' | sed -E s/'\:'/' '/)
+    
+    # get total count
+    (( wallTimeN = ${#wallTimeSortA[@]} ))
+  
+    # get unique times and counts and populate inverse mapping arrays
+    wallTimeCDF_map0=()
+    wallTimeCDF_map=()
+
+    # get map from time -> CDF index and then weight each CDF index by the total time shown at that index
+    while read -r a b c; do
+        { [[ $a ]] && [[ $b ]] && [[ $c ]]; } || continue
+        (( n = ( ( b - 1 ) << 1 ) + a ))
+        (( wallTimeCDF_map[$n] = ${wallTimeCDF_map[$n]:-0} + a * c ))
+        wallTimeCDF_map0[$c]="$n"
+    done < <(printf '%s\n' "${wallTimeSortA[@]}" | uniq -c -f1)
+
+    # cummulative sum weighted CDF to get final "equal screen space" mapping
+    kk0=-1
+    for n in "${!wallTimeCDF_map[@]}"; do
+        (( kk0 >= 0 )) && (( wallTimeCDF_map[$n] = wallTimeCDF_map[$n] + wallTimeCDF_map[$kk0] ))
+        kk0=${n}
+    done
+    wallTimeCDF_csum="${wallTimeCDF_map[$n]}"
+
+    # renormalize final mapping to range between 0 and (2 * numSamples)
+    for n in "${!wallTimeCDF_map[@]}"; do
+        (( wallTimeCDF_map[$n] = ( ( wallTimeN * wallTimeCDF_map[$n] ) << 1 ) / wallTimeCDF_csum ))
+    done
+
+    # if we alsio have cpu times, repeat the above steps to get a weighted CDF mapping for those too
+    ${cpuTimeFlag} && {
+        mapfile -t cpuTimeSortA < <( printf '%s\n' "${cpuTimeA[@]}" | sort -n | grep -nE '' | sed -E s/'\:'/' '/)
+
+        (( cpuTimeN = ${#cpuTimeSortA[@]} ))
+
+        cpuTimeCDF_map0=()
+        cpuTimeCDF_map=()
+
+         while read -r a b c; do
+            { [[ $a ]] && [[ $b ]] && [[ $c ]]; } || continue
+            (( n = ( ( b - 1 ) << 1 ) + a ))
+            (( cpuTimeCDF_map[$n] = ${cpuTimeCDF_map[$n]:-0} + a * c ))
+            cpuTimeCDF_map0[$c]="$n"
+        done < <(printf '%s\n' "${cpuTimeSortA[@]}" | uniq -c -f1)
+
+        kk0=-1
+        for n in "${!cpuTimeCDF_map[@]}"; do
+            (( kk0 >= 0 )) && (( cpuTimeCDF_map[$n] = cpuTimeCDF_map[$n] + cpuTimeCDF_map[$kk0] ))
+            kk0=${n}
+        done
+        cpuTimeCDF_csum="${cpuTimeCDF_map[$n]}"
+
+        for n in "${!cpuTimeCDF_map[@]}"; do
+            (( cpuTimeCDF_map[$n] = ( ( cpuTimeN * cpuTimeCDF_map[$n] ) << 1 ) / cpuTimeCDF_csum ))
+        done
+    }
+
+    # re-create log with time(s) mapped to weighted CDF index
+    if ${cpuTimeFlag}; then
+        for kk in "${!stackA[@]}"; do
+            printf '%s\t %s:%s\t %s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}" "${cpuTimeA[$kk]}" "${cpuTimeCDF_map[${cpuTimeCDF_map0[${cpuTimeA[$kk]}]}]}" 
+        done 
+    else
+        for kk in "${!stackA[@]}"; do
+            printf '%s\t %s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}"
+        done 
+    fi
+}
+
+until (( $# == 0 )); do
+    stackcollapse-time "${1}"
+    shift 1
+done

--- a/stackcollapse-time.bash
+++ b/stackcollapse-time.bash
@@ -98,11 +98,11 @@ stackcollapse-time() {
     # re-create log with time(s) mapped to weighted CDF index
     if ${cpuTimeFlag}; then
         for kk in "${!stackA[@]}"; do
-            printf '%s\t %s:%s\t %s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}" "${cpuTimeA[$kk]}" "${cpuTimeCDF_map[${cpuTimeCDF_map0[${cpuTimeA[$kk]}]}]}" 
+            printf '%s\t%s:%s\t%s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}" "${cpuTimeA[$kk]}" "${cpuTimeCDF_map[${cpuTimeCDF_map0[${cpuTimeA[$kk]}]}]}" 
         done 
     else
         for kk in "${!stackA[@]}"; do
-            printf '%s\t %s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}"
+            printf '%s\t%s:%s\n' "${stackA[$kk]}" "${wallTimeA[$kk]}" "${wallTimeCDF_map[${wallTimeCDF_map0[${wallTimeA[$kk]}]}]}"
         done 
     fi
 }

--- a/stackcollapse-time.bash
+++ b/stackcollapse-time.bash
@@ -4,7 +4,8 @@ stackcollapse-time() {
 ## Emperically creates a non-linear colorspace mapping (using a screen-space-weighted  CDF) that 
 #      ensure that the colorspace is perceptually uniform and has equal spatial distribution.
 #
-# USAGE:   _timep_PROCESS_FLAMEGRAPH out.folded >out.folded.mod
+# USAGE:   stackcollapse-time out.folded >out.folded.mod
+#          stackcollapse-time <out.folded | flamegraph.pl ( --time | --color=time[p[r]] )
 #
 # OUTPUT:  for each line in out.folded:
 #    a;b;c;d; time [time2] --> a;b;c;d; time:ind [time2:ind2]
@@ -106,7 +107,11 @@ stackcollapse-time() {
     fi
 }
 
-until (( $# == 0 )); do
-    stackcollapse-time "${1}"
-    shift 1
-done
+if (( $! == 0 )) && ! [[ -t 0 ]]; then
+    stackcollapse-time <(cat <&0)
+else
+    until (( $# == 0 )); do
+        stackcollapse-time "${1}"
+        shift 1
+    done
+fi


### PR DESCRIPTION
## Summary by Sourcery

Enable flamegraph.pl to apply perceptually uniform time-based coloring using wall-clock and CPU time metrics, and provide a helper script to preprocess folded stack data with computed color indices.

New Features:
- Add time-based coloring options (--time, --color=time[p][r]) to flamegraph.pl
- Implement color_timep function to compute RGB values from wall-clock and CPU time distributions
- Extend flamegraph.pl to parse colon-separated wall/CPU sample counts and color indices
- Introduce stackcollapse-time.bash script to generate weighted CDF indices for folded stacks

Enhancements:
- Update available palettes to include time, timep, and timepr modes
- Warn on misuse of time-based coloring without appropriate input preprocessing